### PR TITLE
bug in charset_to_int

### DIFF
--- a/secretsharing/charset.py
+++ b/secretsharing/charset.py
@@ -21,7 +21,7 @@ def int_to_charset(x, charset):
         x, digit = divmod(x, len(charset))
         output += charset[digit]
     # reverse the characters in the output and return
-    return output[::-1]
+    return output
 
 def charset_to_int(s, charset):
     """ Turn a string into a non-negative integer.
@@ -31,8 +31,10 @@ def charset_to_int(s, charset):
     if (set(s) - set(charset)):
         raise ValueError("s has chars that aren't in the charset.")
     output = 0
+    i=0
     for char in s:
-        output = output * len(charset) + charset.index(char)
+        output = output + (len(charset)**i)*charset.index(char)
+        i+=1
     return output
 
 def change_charset(s, original_charset, target_charset):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -29,10 +29,18 @@ class ShamirSharingTest(unittest.TestCase):
 	def test_hex_to_hex_sharing(self):
 		recovered_secret = self.split_and_recover_secret(SecretSharer, 3, 5,
 			"c4bbcb1fbec99d65bf59d85c8cb62ee2db963f0fe106f483d9afa73bd4e39a8a")
+   
+   	def test_hex_with_zero_to_hex_sharing(self):
+		recovered_secret = self.split_and_recover_secret(SecretSharer, 3, 5,
+			"000ac4bbcb1fbec99d65bf59d85c8cb62ee2db963f0fe106f483d9afa73bd4e39a8a")
 
 	def test_printable_ascii_to_hex_sharing(self):
 		recovered_secret = self.split_and_recover_secret(PlaintextToHexSecretSharer, 3, 5,
 			"correct horse battery staple")
+   
+   	def test_printable_with_zero_ascii_to_hex_sharing(self):
+		recovered_secret = self.split_and_recover_secret(PlaintextToHexSecretSharer, 3, 5,
+			"000correct horse battery staple")
 	
 	def test_b58_to_b32_sharing(self):
 		recovered_secret = self.split_and_recover_secret(BitcoinToB32SecretSharer, 3, 5,


### PR DESCRIPTION
I think there is a bug in function charset_to_int(s, charset). If first character of s parameter is also first character in given charset, character isn't properly encoded to number. 
